### PR TITLE
adding two JS developers

### DIFF
--- a/speakers.yml
+++ b/speakers.yml
@@ -85,6 +85,10 @@
   
 - name: Bridget Kromhout
   twitter: bridgetkromhout
-    
+
+- name: Wes Bos
+  twitter: wesbos
   
+- name: Scott Tolinski
+  twitter: stolinski
   


### PR DESCRIPTION
add Wes Bos and Scott Tolinski, syntax.fm podcasters and front-end/JS developers