### PR TITLE
Fix Security Tag Casing

### DIFF
--- a/videos/41_ILy8e0e8.yml
+++ b/videos/41_ILy8e0e8.yml
@@ -1,5 +1,5 @@
 tags:
- - Security
+ - security
 speaker:
   name: Nicolas Fränkel
   twitter: nicolas_frankel


### PR DESCRIPTION
Fixes the casing of the security tag on the video "Securing the JVM - Neither for fun nor for profit, but do you have a choice?"