### PR TITLE
Fixes casing on Android tag

### DIFF
--- a/videos/CIuYnFooeMM.yml
+++ b/videos/CIuYnFooeMM.yml
@@ -1,6 +1,6 @@
 tags:
   - Continuous Integration
-  - Android
+  - android
 speaker:
   name: Nicolas Fränkel
   twitter: nicolas_frankel


### PR DESCRIPTION
Merges this video back into the main Android tag, rather than the one with improper casing.