### PR TITLE
Adding BxJS Weekly podcast

### DIFF
--- a/channels.yml
+++ b/channels.yml
@@ -1090,3 +1090,8 @@ channels:
     link: https://www.youtube.com/channel/UCdcsr2L2WC0OON39Ar3hBKQ
     playlistId: UUdcsr2L2WC0OON39Ar3hBKQ
     category: vlog
+    
+  - name: Tim Ermilov
+    link: https://www.youtube.com/channel/UCPkKhlR0sXtN5hlB228xuTg
+    playlistId: PL_gX69xPLi-mqs5BJe-xPnOPT6K1Y5_ZQ
+    category: podcast  

--- a/channels.yml
+++ b/channels.yml
@@ -1094,4 +1094,4 @@ channels:
   - name: Tim Ermilov
     link: https://www.youtube.com/channel/UCPkKhlR0sXtN5hlB228xuTg
     playlistId: PL_gX69xPLi-mqs5BJe-xPnOPT6K1Y5_ZQ
-    category: podcast  
+    category: vlog  


### PR DESCRIPTION
Actually BxJS doesnt only cover podcast/stream and news about Javascript but mostly Javascript, Tim teach a lot about programming beside a podcast/news. but the main show here are podcast/news. he also make a [proposal](https://github.com/BuildingXwithJS/proposals) about what to cover next stream/podcast

Usefull link about this channel :

- [main repo](https://github.com/BuildingXwithJS/bxjs-weekly)
- [website](https://bxjs.dev)