### PR TITLE
Adding Gleicon Moraes to speakers file

### DIFF
--- a/speakers.yml
+++ b/speakers.yml
@@ -360,3 +360,6 @@
 
 - name: Matheus Castiglioni
   twitter: mahenrique94
+ 
+- name: Gleicon Moraes
+  twitter: gleicon


### PR DESCRIPTION
Gleicon has some nice talks like this one:

"Como arquiteturas de dados quebram e como consertá-las - Gleicon Moraes"
https://www.youtube.com/watch?v=8SWAeh9HwEs

Hosted on InfoQ Brazil channel on youtube (already exists an entry on channels.yml)